### PR TITLE
IN_MANAGER_MODE

### DIFF
--- a/assets/plugins/simpletube/ajax.php
+++ b/assets/plugins/simpletube/ajax.php
@@ -1,5 +1,7 @@
 <?php
 define('MODX_API_MODE', true);
+define('IN_MANAGER_MODE', true);
+
 include_once(__DIR__."/../../../index.php");
 $modx->db->connect();
 if (empty ($modx->config)) {


### PR DESCRIPTION
Переопределение константы приводит ошибке уровня E_NOTICE. В целом это не критично, т.к. если включить вывод ошибок такого уровня, то можно сойти с ума в MODX Evolution. Ну а чтобы спалось спокойней, я отправил PR dmi3yy/modx.evo.custom#244, проверяющий существование данной константы.