### PR TITLE
Не создается сниппет

### DIFF
--- a/install/assets/snippets/stLister.tpl
+++ b/install/assets/snippets/stLister.tpl
@@ -13,4 +13,3 @@
  */
 
 return require MODX_BASE_PATH.'assets/snippets/simpletube/snippet.stLister.php';
-?>


### PR DESCRIPTION
Возможно, из-за этого закрывающего тега `?>` в коде сниппета **stLister** в Админке при установке из Экстрас получается вот что:

```
<?php
File not found: assets/snippets/simpletube/snippet.stLister.php
?>
```